### PR TITLE
Improved wav_loader function to consistently handle the dtypes and normalization 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "scipy==1.12.0",
         "scikit-learn==1.4.0",
         "seaborn>=0.12.2",
-        "pydub==0.25.1",
         "soundfile==0.12.1",
         "tsaug==0.2.1",
         "resampy==0.4.2",


### PR DESCRIPTION
## Inconsistent WAV File Loading Behavior Across Libraries

scipy.io.wavfile and pydub load audio data in the native PCM encoding of the file, without automatic normalization.
`soundfile` offers a dtype argument to control the output data type.
* For floats (float32, float64), it normalizes to [-1, 1] regardless of the original encoding.
* For integers (int16, int32), it preserves the original encoding but ensures values are within the correct range.
This inconsistency can lead to unexpected results and requires careful handling of data types and normalization depending on the chosen library.

The modified wav_loader implementation resolves this by:
* Allowing explicit control of the output dtype (e.g., float32, int16).
* Consistently normalizing float types to [-1, 1], while preserving the original encoding for integer types.
* Implementing library-specific adjustments to ensure uniform behavior across different loading modes.

Finally, pydub mode was removed for deprecation and redundancy purposes.