### PR TITLE
CTS-62 feat: return also sample rate to wav_loader

### DIFF
--- a/caits/augmentation/_augment_1d.py
+++ b/caits/augmentation/_augment_1d.py
@@ -288,7 +288,7 @@ def drift_ts(
         return arr
 
 
-def dropouts_ts(
+def dropout_ts(
         array: np.ndarray,
         p: Union[float, Tuple[float, float], List[float]] = 0.05,
         size: Union[int, Tuple[int, int], List[int]] = 1,

--- a/caits/experimental/fe_statistical.py
+++ b/caits/experimental/fe_statistical.py
@@ -1,0 +1,27 @@
+import math
+import numpy as np
+
+
+def rms_dbfs(arr: np.ndarray) -> float:
+    """Calculates the root mean square of an audio signal using math module.
+
+    Args:
+        arr: The input audio signal as a numpy.ndarray.
+
+    Returns:
+        float: The root mean square of the audio signal.
+    """
+    square = 0
+    mean = 0.0
+    root = 0.0
+
+    # Calculate square
+    n = len(arr)
+    for i in range(0, n):
+        square += (arr[i] ** 2)
+    # Calculate Mean
+    mean = (square / (float)(n))
+    # Calculate Root
+    root = math.sqrt(mean)
+
+    return root

--- a/caits/fe/_loudness.py
+++ b/caits/fe/_loudness.py
@@ -1,5 +1,6 @@
+import math
 import numpy as np
-from math import log
+from ._statistical import rms_value
 
 
 def dBFS(
@@ -19,9 +20,6 @@ def dBFS(
     if not rms:
         return -float("infinity")
     return ratio_to_db(rms / max_possible_amplitude(sample_width))
-
-
-import math
 
 
 def rms_dbfs(arr: np.ndarray) -> float:
@@ -94,6 +92,6 @@ def ratio_to_db(
         return -float('inf')
 
     if using_amplitude:
-        return 20 * log(ratio, 10)
+        return 20 * math.log(ratio, 10)
     else:  # using power
-        return 10 * log(ratio, 10)
+        return 10 * math.log(ratio, 10)

--- a/caits/fe/_loudness.py
+++ b/caits/fe/_loudness.py
@@ -16,35 +16,10 @@ def dBFS(
     Returns:
 
     """
-    rms = rms_dbfs(array)
+    rms = rms_value(array)
     if not rms:
         return -float("infinity")
     return ratio_to_db(rms / max_possible_amplitude(sample_width))
-
-
-def rms_dbfs(arr: np.ndarray) -> float:
-    """Calculates the root mean square of an audio signal using math module.
-
-    Args:
-        arr: The input audio signal as a numpy.ndarray.
-
-    Returns:
-        float: The root mean square of the audio signal.
-    """
-    square = 0
-    mean = 0.0
-    root = 0.0
-
-    # Calculate square
-    n = len(arr)
-    for i in range(0, n):
-        square += (arr[i] ** 2)
-    # Calculate Mean
-    mean = (square / (float)(n))
-    # Calculate Root
-    root = math.sqrt(mean)
-
-    return root
 
 
 def max_possible_amplitude(

--- a/caits/fe/_spectrum.py
+++ b/caits/fe/_spectrum.py
@@ -637,7 +637,11 @@ def power_to_db(
     return log_spec
 
 
-def db_to_power(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
+def db_to_power(
+    S_db: np.ndarray,
+    *,
+    ref: float = 1.0
+) -> np.ndarray:
     # The functionality in this implementation is basically derived from
     # librosa v0.10.1:
     # https://github.com/librosa/librosa/blob/main/librosa/core/spectrum.py
@@ -688,7 +692,11 @@ def amplitude_to_db(
     return power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
 
 
-def db_to_amplitude(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
+def db_to_amplitude(
+    S_db: np.ndarray,
+    *,
+    ref: float = 1.0
+) -> np.ndarray:
     """Convert a dB-scaled spectrogram to an amplitude spectrogram.
 
     This effectively inverts `amplitude_to_db`::

--- a/caits/loading/_audio.py
+++ b/caits/loading/_audio.py
@@ -111,7 +111,7 @@ def audio_loader(
             try:
                 df, _ = wav_loader(file_path, mode, target_sr, dtype, channels)
                 all_features.append(df)
-                # todo: add sample rate to the dictionary
+                # todo: add sample rate, sample width to the dictionary?
                 all_y.append(subdir)
                 all_id.append(file)
             except Exception as e:


### PR DESCRIPTION
Like librosa and other libs, it is good to return the sampling rate, to give the user later on the capability of using it, like other useful info, such as sample width, etc. This info can be columns to the Dataset dataframe