### PR TITLE
CTC-76 Python 3.8 Compatibility

### DIFF
--- a/caits/core/_core_checks.py
+++ b/caits/core/_core_checks.py
@@ -5,7 +5,8 @@
 from typing import Dict, Optional, Union
 
 import numpy as np
-from numpy.typing import DTypeLike
+
+from caits.core.numpy_typing import DTypeLike
 
 
 class Deprecated(object):
@@ -32,9 +33,9 @@ def is_positive_int(x: float) -> bool:
 
 
 def valid_audio(
-    y: np.ndarray,
-    *,
-    mono: Union[bool, Deprecated] = Deprecated()
+        y: np.ndarray,
+        *,
+        mono: Union[bool, Deprecated] = Deprecated()
 ) -> bool:
     if not isinstance(y, np.ndarray):
         raise ValueError("Audio data must be of type numpy.ndarray")
@@ -58,9 +59,9 @@ def valid_audio(
 
 
 def dtype_r2c(
-    d: DTypeLike,
-    *,
-    default: Optional[type] = np.complex64
+        d: DTypeLike,
+        *,
+        default: Optional[type] = np.complex64
 ) -> DTypeLike:
     mapping: Dict[DTypeLike, type] = {
         np.dtype(np.float32): np.complex64,
@@ -79,9 +80,9 @@ def dtype_r2c(
 
 
 def dtype_c2r(
-    d: DTypeLike,
-    *,
-    default: Optional[type] = np.float32
+        d: DTypeLike,
+        *,
+        default: Optional[type] = np.float32
 ) -> DTypeLike:
     mapping: Dict[DTypeLike, type] = {
         np.dtype(np.complex64): np.float32,

--- a/caits/core/_core_typing.py
+++ b/caits/core/_core_typing.py
@@ -4,8 +4,9 @@
 from typing import Any, Callable, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
-from numpy.typing import ArrayLike
 from typing_extensions import Literal
+
+from caits.core.numpy_typing import ArrayLike
 
 _Real = Union[float, "np.integer[Any]", "np.floating[Any]"]
 _Number = Union[complex, "np.number[Any]"]

--- a/caits/core/_core_window.py
+++ b/caits/core/_core_window.py
@@ -3,7 +3,8 @@ from typing import Any, Callable, Optional, Tuple, Union
 import numpy as np
 import scipy
 from numpy.lib.stride_tricks import as_strided
-from numpy.typing import ArrayLike, DTypeLike
+
+from caits.core.numpy_typing import ArrayLike, DTypeLike
 
 from ._core_typing import _FloatLike_co, _WindowSpec
 
@@ -76,11 +77,11 @@ def window_sumsquare(
 
 
 def pad_center(
-    data: np.ndarray,
-    *,
-    size: int,
-    axis: int = -1,
-    **kwargs: Any
+        data: np.ndarray,
+        *,
+        size: int,
+        axis: int = -1,
+        **kwargs: Any
 ) -> np.ndarray:
     kwargs.setdefault("mode", "constant")
 
@@ -126,7 +127,7 @@ def __window_ss_fill(x, win_sq, n_frames, hop_length):  # pragma: no cover
     n_fft = len(win_sq)
     for i in range(n_frames):
         sample = i * hop_length
-        x[sample : min(n, sample + n_fft)] += win_sq[: max(
+        x[sample: min(n, sample + n_fft)] += win_sq[: max(
             0, min(n_fft, n - sample))]
 
 
@@ -173,7 +174,7 @@ def normalize(
         length = np.sum(mag > 0, axis=axis, keepdims=True, dtype=mag.dtype)
 
     elif np.issubdtype(type(norm), np.number) and norm > 0:
-        length = np.sum(mag**norm, axis=axis, keepdims=True) ** (1.0 / norm)
+        length = np.sum(mag ** norm, axis=axis, keepdims=True) ** (1.0 / norm)
 
         if axis is None:
             fill_norm = mag.size ** (-1.0 / norm)

--- a/caits/core/numpy_typing/__init__.py
+++ b/caits/core/numpy_typing/__init__.py
@@ -1,0 +1,4 @@
+from .array_like import ArrayLike
+from .dtype_like import DTypeLike
+
+__all__ = ["ArrayLike", "DTypeLike"]

--- a/caits/core/numpy_typing/array_like.py
+++ b/caits/core/numpy_typing/array_like.py
@@ -1,0 +1,112 @@
+from typing import Any, Iterator, Protocol, TypeVar, Union, overload, runtime_checkable
+
+import numpy as np
+
+_T = TypeVar("_T")
+_DType = TypeVar("_DType", bound="np.dtype[Any]")
+_DType_co = TypeVar("_DType_co", covariant=True, bound="np.dtype[Any]")
+
+
+# The `_SupportsArray` protocol only cares about the default dtype
+# (i.e. `dtype=None` or no `dtype` parameter at all) of the to-be returned
+# array.
+# Concrete implementations of the protocol are responsible for adding
+# any and all remaining overloads
+@runtime_checkable
+class _SupportsArray(Protocol[_DType_co]):
+    def __array__(self) -> np.ndarray: ...
+
+
+_T_co = TypeVar("_T_co", covariant=True)
+
+
+@runtime_checkable
+class _NestedSequence(Protocol[_T_co]):
+    """A protocol for representing nested sequences.
+
+    Warning
+    -------
+    `_NestedSequence` currently does not work in combination with typevars,
+    *e.g.* ``def func(a: _NestedSequnce[T]) -> T: ...``.
+
+    See Also
+    --------
+    collections.abc.Sequence
+        ABCs for read-only and mutable :term:`sequences`.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from __future__ import annotations
+
+        >>> from typing import TYPE_CHECKING
+        >>> import numpy as np
+        >>> from numpy._typing import _NestedSequence
+
+        >>> def get_dtype(seq: _NestedSequence[float]) -> np.dtype[np.float64]:
+        ...     return np.asarray(seq).dtype
+
+        >>> a = get_dtype([1.0])
+        >>> b = get_dtype([[1.0]])
+        >>> c = get_dtype([[[1.0]]])
+        >>> d = get_dtype([[[[1.0]]]])
+
+        >>> if TYPE_CHECKING:
+        ...     reveal_locals()
+        ...     # note: Revealed local types are:
+        ...     # note:     a: numpy.dtype[numpy.floating[numpy._typing._64Bit]]
+        ...     # note:     b: numpy.dtype[numpy.floating[numpy._typing._64Bit]]
+        ...     # note:     c: numpy.dtype[numpy.floating[numpy._typing._64Bit]]
+        ...     # note:     d: numpy.dtype[numpy.floating[numpy._typing._64Bit]]
+
+    """
+
+    def __len__(self, /) -> int:
+        """Implement ``len(self)``."""
+        raise NotImplementedError
+
+    @overload
+    def __getitem__(self, index: int, /) -> "_T_co | _NestedSequence[_T_co]": ...
+    @overload
+    def __getitem__(self, index: slice, /) -> "_NestedSequence[_T_co]": ...
+
+    def __getitem__(self, index, /):
+        """Implement ``self[x]``."""
+        raise NotImplementedError
+
+    def __contains__(self, x: object, /) -> bool:
+        """Implement ``x in self``."""
+        raise NotImplementedError
+
+    def __iter__(self, /) -> "Iterator[_T_co | _NestedSequence[_T_co]]":
+        """Implement ``iter(self)``."""
+        raise NotImplementedError
+
+    def __reversed__(self, /) -> "Iterator[_T_co | _NestedSequence[_T_co]]":
+        """Implement ``reversed(self)``."""
+        raise NotImplementedError
+
+    def count(self, value: Any, /) -> int:
+        """Return the number of occurrences of `value`."""
+        raise NotImplementedError
+
+    def index(self, value: Any, /) -> int:
+        """Return the first index of `value`."""
+        raise NotImplementedError
+
+
+# A union representing array-like objects; consists of two typevars:
+# One representing types that can be parametrized w.r.t. `np.dtype`
+# and another one for the rest
+_DualArrayLike = Union[
+    _SupportsArray[_DType],
+    _NestedSequence[_SupportsArray[_DType]],
+    _T,
+    _NestedSequence[_T],
+]
+
+ArrayLike = _DualArrayLike[
+    np.dtype,
+    Union[bool, int, float, complex, str, bytes],
+]

--- a/caits/core/numpy_typing/dtype_like.py
+++ b/caits/core/numpy_typing/dtype_like.py
@@ -1,0 +1,79 @@
+from typing import (
+    Any,
+    List,
+    Protocol,
+    Sequence,
+    SupportsIndex,
+    Tuple,
+    Type,
+    TypedDict,
+    TypeVar,
+    Union,
+    runtime_checkable,
+)
+
+import numpy as np
+
+_DType_co = TypeVar("_DType_co", covariant=True, bound="np.dtype[Any]")
+
+_DTypeLikeNested = Any  # TODO: wait for support for recursive types
+
+_ShapeLike = Union[SupportsIndex, Sequence[SupportsIndex]]
+
+
+# Mandatory keys
+class _DTypeDictBase(TypedDict):
+    names: Sequence[str]
+    formats: Sequence[_DTypeLikeNested]
+
+
+# Mandatory + optional keys
+class _DTypeDict(_DTypeDictBase, total=False):
+    # Only `str` elements are usable as indexing aliases,
+    # but `titles` can in principle accept any object
+    offsets: Sequence[int]
+    titles: Sequence[Any]
+    itemsize: int
+    aligned: bool
+
+
+# A protocol for anything with the dtype attribute
+@runtime_checkable
+class _SupportsDType(Protocol[_DType_co]):
+    @property
+    def dtype(self) -> _DType_co: ...
+
+
+# Would create a dtype[np.void]
+_VoidDTypeLike = Union[
+    # (flexible_dtype, itemsize)
+    Tuple[_DTypeLikeNested, int],
+    # (fixed_dtype, shape)
+    Tuple[_DTypeLikeNested, _ShapeLike],
+    # [(field_name, field_dtype, field_shape), ...]
+    #
+    # The type here is quite broad because NumPy accepts quite a wide
+    # range of inputs inside the list; see the tests for some
+    # examples.
+    List[Any],
+    # {'names': ..., 'formats': ..., 'offsets': ..., 'titles': ...,
+    #  'itemsize': ...}
+    _DTypeDict,
+    # (base_dtype, new_dtype)
+    Tuple[_DTypeLikeNested, _DTypeLikeNested],
+]
+
+# Anything that can be coerced into numpy.dtype.
+# Reference: https://docs.scipy.org/doc/numpy/reference/arrays.dtypes.html
+DTypeLike = Union[
+    np.dtype,
+    # default data type (float64)
+    None,
+    # array-scalar types and generic types
+    Type[Any],  # NOTE: We're stuck with `Type[Any]` due to object dtypes
+    # anything with a dtype attribute
+    _SupportsDType[np.dtype],
+    # character codes, type strings or comma-separated fields, e.g., 'float64'
+    str,
+    _VoidDTypeLike,
+]

--- a/caits/fe/_spectrum.py
+++ b/caits/fe/_spectrum.py
@@ -7,18 +7,18 @@ from typing import Any, Callable, Optional, Tuple, Union
 import numpy as np
 import scipy
 from numpy import fft
-from numpy.typing import ArrayLike, DTypeLike
+
+from caits.core.numpy_typing import ArrayLike, DTypeLike
 
 from ..core._core_checks import dtype_c2r, dtype_r2c, is_positive_int, valid_audio
 from ..core._core_fix import fix_length
 from ..core._core_typing import _ComplexLike_co, _PadModeSTFT, _ScalarOrSequence, _WindowSpec
 from ..core._core_window import frame, get_window, pad_center, tiny, window_sumsquare
-
 from .core_spectrum import __overlap_add, expand_to
 from .core_spectrum._utils import mel_filter
 
 # Constrain STFT block sizes to 256 KB
-MAX_MEM_BLOCK = 2**8 * 2**10
+MAX_MEM_BLOCK = 2 ** 8 * 2 ** 10
 
 
 def stft(
@@ -133,7 +133,7 @@ def stft(
             # Determine if we have any frames that will fit inside the tail pad
             if tail_k * hop_length - n_fft // 2 + n_fft <= y.shape[-1] + n_fft // 2:
                 padding[-1] = (0, n_fft // 2)
-                y_post = np.pad(y[..., (tail_k) * hop_length - n_fft // 2 :], padding, mode=pad_mode)
+                y_post = np.pad(y[..., (tail_k) * hop_length - n_fft // 2:], padding, mode=pad_mode)
                 y_frames_post = frame(y_post, frame_length=n_fft, hop_length=hop_length)
                 # How many extra frames do we have from the tail?
                 extra += y_frames_post.shape[-1]
@@ -200,7 +200,7 @@ def stft(
     for bl_s in range(0, y_frames.shape[-1], n_columns):
         bl_t = min(bl_s + n_columns, y_frames.shape[-1])
 
-        stft_matrix[..., bl_s + off_start : bl_t + off_start] = fft.rfft(fft_window * y_frames[..., bl_s:bl_t], axis=-2)
+        stft_matrix[..., bl_s + off_start: bl_t + off_start] = fft.rfft(fft_window * y_frames[..., bl_s:bl_t], axis=-2)
     return stft_matrix
 
 
@@ -287,10 +287,10 @@ def istft(
 
         # If y is smaller than the head buffer, take everything
         if y.shape[-1] < shape[-1] - n_fft // 2:
-            y[..., :] = head_buffer[..., n_fft // 2 : y.shape[-1] + n_fft // 2]
+            y[..., :] = head_buffer[..., n_fft // 2: y.shape[-1] + n_fft // 2]
         else:
             # Trim off the first n_fft//2 samples from the head and copy into target buffer
-            y[..., : shape[-1] - n_fft // 2] = head_buffer[..., n_fft // 2 :]
+            y[..., : shape[-1] - n_fft // 2] = head_buffer[..., n_fft // 2:]
 
         # This offset compensates for any differences between frame alignment
         # and padding truncation
@@ -311,7 +311,7 @@ def istft(
         ytmp = ifft_window * fft.irfft(stft_matrix[..., bl_s:bl_t], n=n_fft, axis=-2)
 
         # Overlap-add the istft block starting at the i'th frame
-        __overlap_add(y[..., frame * hop_length + offset :], ytmp, hop_length)
+        __overlap_add(y[..., frame * hop_length + offset:], ytmp, hop_length)
 
         frame += bl_t - bl_s
 
@@ -592,7 +592,7 @@ def amplitude_to_db(
 
     power = np.square(magnitude, out=magnitude)
 
-    return power_to_db(power, ref=ref_value**2, amin=amin**2, top_db=top_db)
+    return power_to_db(power, ref=ref_value ** 2, amin=amin ** 2, top_db=top_db)
 
 
 def db_to_amplitude(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
@@ -605,4 +605,4 @@ def db_to_amplitude(S_db: np.ndarray, *, ref: float = 1.0) -> np.ndarray:
     # The functionality in this implementation is basically derived from
     # librosa v0.10.1:
     # https://github.com/librosa/librosa/blob/main/librosa/core/spectrum.py
-    return db_to_power(S_db, ref=ref**2) ** 0.5
+    return db_to_power(S_db, ref=ref ** 2) ** 0.5

--- a/caits/fe/core_spectrum/_utils.py
+++ b/caits/fe/core_spectrum/_utils.py
@@ -8,13 +8,13 @@ from typing import Any, List, Literal, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import scipy
-from numpy.typing import DTypeLike
 
 from caits.core._core_typing import _FloatLike_co, _ScalarOrSequence
 from caits.core._core_window import normalize
+from caits.core.numpy_typing import DTypeLike
 
 # Constrain STFT block sizes to 256 KB
-MAX_MEM_BLOCK = 2**8 * 2**10
+MAX_MEM_BLOCK = 2 ** 8 * 2 ** 10
 
 
 def expand_to(x: np.ndarray, *, ndim: int, axes: Union[int, slice, Sequence[int], Sequence[slice]]) -> np.ndarray:
@@ -51,7 +51,7 @@ def __overlap_add(y, ytmp, hop_length):
         if N > y.shape[-1] - sample:
             N = y.shape[-1] - sample
 
-        y[..., sample : (sample + N)] += ytmp[..., :N, frame]
+        y[..., sample: (sample + N)] += ytmp[..., :N, frame]
 
 
 def _nnls_obj(x: np.ndarray, shape: Sequence[int], A: np.ndarray, B: np.ndarray) -> Tuple[float, np.ndarray]:
@@ -64,7 +64,7 @@ def _nnls_obj(x: np.ndarray, shape: Sequence[int], A: np.ndarray, B: np.ndarray)
     diff = np.einsum("mf,...ft->...mt", A, x, optimize=True) - B
 
     # Compute the objective value
-    value = (1 / B.size) * 0.5 * np.sum(diff**2)
+    value = (1 / B.size) * 0.5 * np.sum(diff ** 2)
 
     # And the gradient
     grad = (1 / B.size) * np.einsum("mf,...mt->...ft", A, diff, optimize=True)
@@ -195,7 +195,7 @@ def mel_filter(
     if isinstance(norm, str):
         if norm == "slaney":
             # Slaney-style mel is scaled to be approx constant energy per channel
-            enorm = 2.0 / (mel_f[2 : n_mels + 2] - mel_f[:n_mels])
+            enorm = 2.0 / (mel_f[2: n_mels + 2] - mel_f[:n_mels])
             weights *= enorm[:, np.newaxis]
         else:
             raise ValueError(f"Unsupported norm={norm}")
@@ -232,7 +232,7 @@ def mel_frequencies(n_mels: int = 128, *, fmin: float = 0.0, fmax: float = 11025
 
 
 def hz_to_mel(
-    frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False
+        frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False
 ) -> Union[np.floating[Any], np.ndarray]:
     frequencies = np.asanyarray(frequencies)
 

--- a/caits/fe/core_spectrum/_utils.py
+++ b/caits/fe/core_spectrum/_utils.py
@@ -233,7 +233,7 @@ def mel_frequencies(n_mels: int = 128, *, fmin: float = 0.0, fmax: float = 11025
 
 def hz_to_mel(
         frequencies: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False
-) -> Union[np.floating[Any], np.ndarray]:
+) -> Union[np.floating, np.ndarray]:
     frequencies = np.asanyarray(frequencies)
 
     if htk:
@@ -263,7 +263,7 @@ def hz_to_mel(
     return mels
 
 
-def mel_to_hz(mels: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False) -> Union[np.floating[Any], np.ndarray]:
+def mel_to_hz(mels: _ScalarOrSequence[_FloatLike_co], *, htk: bool = False) -> Union[np.floating, np.ndarray]:
     mels = np.asanyarray(mels)
 
     if htk:

--- a/caits/fe/inverse.py
+++ b/caits/fe/inverse.py
@@ -2,12 +2,12 @@ import warnings
 from typing import Any, Optional, Union
 
 import numpy as np
-from numpy.typing import DTypeLike
+
+from caits.core.numpy_typing import DTypeLike
 
 from ..core._core_checks import dtype_r2c
 from ..core._core_typing import _PadModeSTFT, _WindowSpec
 from ..core._core_window import tiny
-
 from ._spectrum import istft, stft
 from .core_spectrum._phase import phasor
 from .core_spectrum._utils import mel_filter, nnls


### PR DESCRIPTION
Ensured codebase is compatible with Python 3.8. Replaced the use of numpy.typing with custom implementation of the `DTypeLike` and `ArrayLike` typings to ensure compatibility with the chaquopy version of the library and removed generics from the `np.floating` type for the same reason