### PR TITLE
fix: apply anti-aliasing filter when resampling audio (#105)

### DIFF
--- a/caits/loading/_audio.py
+++ b/caits/loading/_audio.py
@@ -18,10 +18,14 @@ def wav_loader(
     mode: str = "soundfile",
     target_sr: Optional[int] = None,
     dtype: str = "float64",
-    channels: Optional[List[str]] = None
+    channels: Optional[List[str]] = None,
+    res_type: str = "soxr_hq",
 ) -> Tuple[CoreArray, int]:
     """Loads and optionally resamples a mono or multichannel audio
     file into a DataFrame.
+
+    Resampling (when ``target_sr`` differs from the file's native sample rate)
+    applies an anti-aliasing filter via :func:`caits.preprocessing.resample_2d`.
 
     Args:
         file_path: Path to the audio file.
@@ -35,6 +39,8 @@ def wav_loader(
             - "int16": 16-bit signed integer, no normalization
             - "int32": 32-bit signed integer, no normalization
         channels: List of channel names for the DataFrame.
+        res_type: Resampling backend / quality (default ``"soxr_hq"``).
+            Forwarded to :func:`caits.preprocessing.resample_2d`.
 
     Returns:
         pd.DataFrame: Loaded and optionally resampled audio data in 2D shape.
@@ -53,12 +59,13 @@ def wav_loader(
         raise ValueError(f"Unsupported mode: {mode}")
 
     if target_sr is not None and target_sr != sample_rate:
-        # Resamples audio to target_sr per channel
+        # Resamples audio to target_sr per channel (with anti-aliasing).
         audio_data = resample_2d(
             audio_data=audio_data,
             native_sr=sample_rate,
             target_sr=target_sr,
-            dtype=dtype
+            dtype=dtype,
+            res_type=res_type,
         )
     else:
         target_sr = sample_rate
@@ -80,10 +87,14 @@ def audio_loader(
     target_sr: Optional[List[int]] = None,
     classes: Optional[List[str]] = None,
     channels: List[str] = ["Ch_1"],
-    export: Literal["df", "dict"] = "dict"
+    export: Literal["df", "dict"] = "dict",
+    res_type: str = "soxr_hq",
 ) -> Union[pd.DataFrame, Dict[str, List]]:
     """Loads audio files from a directory into a DataFrame
     or dictionary with optional resampling.
+
+    Resampling (when ``target_sr`` differs from the file's native sample rate)
+    applies an anti-aliasing filter via :func:`caits.preprocessing.resample_2d`.
 
     Args:
         dataset_path: Path to the dataset directory.
@@ -101,6 +112,8 @@ def audio_loader(
                  if None, all directories are included.
         channels: List of channel names for the DataFrame.
         export: Format to export the loaded data, "dict" or "df" for DataFrame.
+        res_type: Resampling backend / quality (default ``"soxr_hq"``).
+            Forwarded to :func:`wav_loader`.
 
     Returns:
         pd.DataFrame or dict: Loaded and optionally resampled audio
@@ -120,7 +133,10 @@ def audio_loader(
         if classes is None or subdir in classes:
             file = os.path.basename(file_path)
             try:
-                df, _ = wav_loader(file_path, mode, target_sr, dtype, channels)
+                df, _ = wav_loader(
+                    file_path, mode, target_sr, dtype, channels,
+                    res_type=res_type,
+                )
                 all_features.append(df)
                 # todo: add sample rate, sample width to the dictionary?
                 all_y.append(subdir)

--- a/caits/loading/_s3_audio.py
+++ b/caits/loading/_s3_audio.py
@@ -17,9 +17,13 @@ def s3_wav_loader(
     target_sr: Optional[int] = None,
     dtype: str = "float64",
     channels: Optional[List[str]] = None,
+    res_type: str = "soxr_hq",
 ) -> Tuple[pd.DataFrame, int]:
     """Loads and optionally resamples a mono or multichannel audio
     file from bytes into a DataFrame.
+
+    Resampling (when ``target_sr`` differs from the file's native sample rate)
+    applies an anti-aliasing filter via :func:`caits.preprocessing.resample_2d`.
 
     Args:
         file_content: The audio file as bytes.
@@ -31,6 +35,8 @@ def s3_wav_loader(
             - "int16": 16-bit signed integer, no normalization
             - "int32": 32-bit signed integer, no normalization
         channels: List of channel names for the DataFrame.
+        res_type: Resampling backend / quality (default ``"soxr_hq"``).
+            Forwarded to :func:`caits.preprocessing.resample_2d`.
 
     Returns:
         pd.DataFrame: Loaded and optionally resampled audio data in 2D shape.
@@ -52,8 +58,14 @@ def s3_wav_loader(
         raise ValueError(f"Unsupported mode: {mode}")
 
     if target_sr is not None and target_sr != sample_rate:
-        # Resamples audio to target_sr per channel
-        audio_data = resample_2d(audio_data, sample_rate, target_sr, dtype)
+        # Resamples audio to target_sr per channel (with anti-aliasing).
+        audio_data = resample_2d(
+            audio_data=audio_data,
+            native_sr=sample_rate,
+            target_sr=target_sr,
+            dtype=dtype,
+            res_type=res_type,
+        )
         sample_rate = target_sr
 
     if channels is None or len(channels) != audio_data.shape[1]:
@@ -73,6 +85,7 @@ def s3_audio_loader(
     classes: Optional[List[str]] = None,
     channels: Optional[List[str]] = None,
     export: Literal["df", "dict"] = "dict",
+    res_type: str = "soxr_hq",
 ) -> Union[pd.DataFrame, dict]:
     """Loads audio files from an S3 bucket into a DataFrame or dictionary with optional resampling.
 
@@ -128,6 +141,7 @@ def s3_audio_loader(
                     target_sr=target_sr,
                     dtype=dtype,
                     channels=channels,
+                    res_type=res_type,
                 )
                 all_features.append(df)
                 all_y.append(subdir)

--- a/caits/preprocessing.py
+++ b/caits/preprocessing.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .core._core_resample import resample
+
 
 def normalize_signal(sig: np.ndarray, axis: int = 0) -> np.ndarray:
     """Normalizes a signal to the proper range.
@@ -22,17 +24,19 @@ def normalize_signal(sig: np.ndarray, axis: int = 0) -> np.ndarray:
 
 
 def resample_signal(
-    sig: np.ndarray, 
-    native_sr: int, 
-    target_sr: int, 
+    sig: np.ndarray,
+    native_sr: int,
+    target_sr: int,
     dtype: str = "float32"
 ) -> np.ndarray:
-    """Resamples an audio signal to the target sampling rate.
+    """Resamples an audio signal to the target sampling rate via linear interpolation.
 
-    This function prioritizes computational accuracy by performing the resampling
-    internally using the highest precision available (usually float64). However,
-    the final result is cast to the specified `dtype` to ensure the output matches
-    the desired format.
+    .. deprecated::
+        This function uses ``np.interp`` and does NOT apply an anti-aliasing
+        filter. When downsampling, frequencies above the target Nyquist will
+        alias into the output. Prefer :func:`resample_2d` (which delegates to
+        :func:`caits.core._core_resample.resample` with a proper AAF) or call
+        ``caits.core._core_resample.resample`` directly.
 
     Args:
         sig: The input audio signal as a NumPy array.
@@ -61,24 +65,38 @@ def resample_signal(
 
 
 def resample_2d(
-    audio_data: np.ndarray, 
-    native_sr: int, 
+    audio_data: np.ndarray,
+    native_sr: int,
     target_sr: int,
     axis: int = 0,
-    dtype: str = "float32"
+    dtype: str = "float32",
+    res_type: str = "soxr_hq",
 ) -> np.ndarray:
     """Resamples 2D audio data (multi-channel) to a target sampling rate.
 
+    Resampling is delegated to :func:`caits.core._core_resample.resample`, which
+    applies a proper anti-aliasing filter (AAF) before decimation. The default
+    ``res_type="soxr_hq"`` uses SoX's high-quality Kaiser-windowed sinc filter.
+
     Args:
         audio_data: The input audio data as a 2D numpy (n_samples, n_channels).
+            A 1D array of shape (n_samples,) is also accepted and expanded to
+            (n_samples, 1).
         native_sr: The native sampling rate of the input audio data.
         target_sr: The target sampling rate as integer.
+        axis: Axis along which to resample. Defaults to 0 (samples axis).
+        dtype: Output dtype.
+        res_type: Resampling backend / quality. Forwarded to
+            :func:`caits.core._core_resample.resample`. Common choices:
+            ``"soxr_hq"`` (default, high quality), ``"polyphase"``
+            (scipy.signal.resample_poly, integer rates only), ``"scipy"``
+            (FFT-based), ``"sinc_best"`` (libsamplerate). All apply AAF.
 
     Returns:
         np.ndarray: The resampled audio data as a 2D numpy.ndarray.
 
     Raises:
-        ValueError: If the input `audio_data` is not a 2-dimensional NumPy array.
+        ValueError: If the input ``audio_data`` is not 1-D or 2-D.
     """
 
     # If audio data is 1D (n_samples, ), make it 2D (n_samples, 1)
@@ -88,16 +106,21 @@ def resample_2d(
     # Check if audio data is 2D
     elif audio_data.ndim != 2:
         raise ValueError(
-            "Input audio data must be a 1-dimensional or 2-dimensional NumPy array " "(n_samples, n_channels).")
+            "Input audio data must be a 1-dimensional or 2-dimensional NumPy "
+            "array (n_samples, n_channels)."
+        )
 
-    return np.apply_along_axis(
-        func1d=resample_signal,
-        axis=axis,
-        arr=audio_data,
-        native_sr=native_sr,
+    if native_sr == target_sr:
+        return audio_data.astype(dtype, copy=False)
+
+    resampled = resample(
+        audio_data,
+        orig_sr=native_sr,
         target_sr=target_sr,
-        dtype=dtype
+        res_type=res_type,
+        axis=axis,
     )
+    return resampled.astype(dtype, copy=False)
 
 
 def trim_signal(

--- a/test/tests/test_resample_aaf.py
+++ b/test/tests/test_resample_aaf.py
@@ -1,0 +1,104 @@
+"""Regression tests for issue #105: AAF not Considered when Resampling.
+
+Verifies that ``resample_2d`` applies an anti-aliasing filter when downsampling.
+A pure tone above the *target* Nyquist frequency must be attenuated, not folded
+back into the audible band.
+"""
+import numpy as np
+import pytest
+
+from caits.preprocessing import resample_2d, resample_signal
+
+
+def _tone(freq_hz: float, sr: int, duration_s: float = 1.0) -> np.ndarray:
+    t = np.arange(int(sr * duration_s)) / sr
+    return np.sin(2 * np.pi * freq_hz * t).astype("float64")
+
+
+def _energy_at(sig: np.ndarray, freq_hz: float, sr: int, bw_hz: float = 50.0) -> float:
+    """RMS amplitude in a narrow band around freq_hz."""
+    n = len(sig)
+    spectrum = np.fft.rfft(sig)
+    freqs = np.fft.rfftfreq(n, d=1.0 / sr)
+    mask = (freqs >= freq_hz - bw_hz) & (freqs <= freq_hz + bw_hz)
+    if not mask.any():
+        return 0.0
+    # Parseval-style band energy, normalized to a comparable scale.
+    return float(np.sqrt(np.sum(np.abs(spectrum[mask]) ** 2)) / n)
+
+
+def test_resample_2d_suppresses_aliasing_on_downsample():
+    """A 7 kHz tone in a 16 kHz signal downsampled to 8 kHz must NOT alias to 1 kHz.
+
+    Target Nyquist = 4 kHz; 7 kHz would fold to |7 - 8| = 1 kHz without an AAF.
+    """
+    native_sr = 16_000
+    target_sr = 8_000
+    tone_freq = 7_000  # above target Nyquist (4 kHz)
+    alias_freq = abs(tone_freq - target_sr)  # 1 kHz
+
+    sig = _tone(tone_freq, native_sr, duration_s=1.0)
+
+    out = resample_2d(sig, native_sr=native_sr, target_sr=target_sr, dtype="float64")
+    assert out.shape[1] == 1
+    out_1d = out[:, 0]
+
+    alias_energy = _energy_at(out_1d, alias_freq, target_sr)
+    # Reference: same tone at the alias frequency, same length, so we can compare scales.
+    ref = _tone(alias_freq, target_sr, duration_s=len(out_1d) / target_sr)
+    ref_energy = _energy_at(ref, alias_freq, target_sr)
+
+    # AAF should knock the alias down by at least 40 dB vs. a real tone of the same amplitude.
+    ratio_db = 20 * np.log10(max(alias_energy, 1e-12) / max(ref_energy, 1e-12))
+    assert ratio_db < -40, (
+        f"Alias at {alias_freq} Hz not sufficiently suppressed: "
+        f"{ratio_db:.1f} dB vs. reference tone (expected < -40 dB)"
+    )
+
+
+def test_resample_signal_legacy_aliases_as_documented():
+    """Sanity check: the legacy np.interp path DOES alias.
+
+    Locks in that the new ``resample_2d`` path is doing real work — if this test
+    starts failing (legacy no longer aliases), something has changed in the
+    legacy implementation and the contrast assertion above may be invalidated.
+    """
+    native_sr = 16_000
+    target_sr = 8_000
+    tone_freq = 7_000
+    alias_freq = abs(tone_freq - target_sr)
+
+    sig = _tone(tone_freq, native_sr, duration_s=1.0)
+    out = resample_signal(sig, native_sr=native_sr, target_sr=target_sr, dtype="float64")
+
+    alias_energy = _energy_at(out, alias_freq, target_sr)
+    # The legacy path produces measurable energy at the alias bin.
+    assert alias_energy > 1e-3, (
+        f"Legacy resample_signal unexpectedly suppressed the alias bin "
+        f"({alias_energy:.2e}); test premise may be stale."
+    )
+
+
+def test_resample_2d_preserves_inband_tone():
+    """A tone well below the target Nyquist must survive resampling intact."""
+    native_sr = 16_000
+    target_sr = 8_000
+    tone_freq = 1_000  # well below target Nyquist (4 kHz)
+
+    sig = _tone(tone_freq, native_sr, duration_s=1.0)
+    out = resample_2d(sig, native_sr=native_sr, target_sr=target_sr, dtype="float64")
+    out_1d = out[:, 0]
+
+    inband = _energy_at(out_1d, tone_freq, target_sr)
+    assert inband > 1e-2, f"In-band tone lost after resampling: energy={inband:.2e}"
+
+
+@pytest.mark.parametrize("native_sr,target_sr", [(48_000, 16_000), (44_100, 22_050)])
+def test_resample_2d_shape_and_dtype(native_sr, target_sr):
+    """Output shape matches the resampling ratio and dtype is honored."""
+    duration = 0.5
+    sig = np.random.default_rng(0).standard_normal(int(native_sr * duration))
+    out = resample_2d(sig, native_sr=native_sr, target_sr=target_sr, dtype="float32")
+    expected_n = int(np.ceil(len(sig) * target_sr / native_sr))
+    assert out.shape == (expected_n, 1)
+    assert out.dtype == np.float32


### PR DESCRIPTION
## Summary

Closes #105.

- ` caits/preprocessing.py::resample_2d ` now delegates to the existing `caits/core/_core_resample.py::resample` (default `soxr_hq`) instead of `np.interp`. Downsampling now applies a proper anti-aliasing filter (Kaiser-windowed sinc via SoX), so frequencies above the target Nyquist are attenuated rather than folded back into the audible band.
- Added `res_type` parameter (default `"soxr_hq"`) to `wav_loader`, `audio_loader`, `s3_wav_loader`, and `s3_audio_loader` so callers can pick a different backend (`polyphase`, `scipy`, `sinc_best`, etc.) — all of which apply AAF.
- Fixed a pre-existing positional-argument bug in `s3_wav_loader` where `dtype` was being passed as the `axis` parameter to `resample_2d` (`_s3_audio.py:56`). This made `test_s3_wav_loader_resample` pass for the first time.
- Kept `resample_signal` (the legacy `np.interp` path) and explicitly marked it deprecated / no-AAF in its docstring, so anyone who imports it directly knows what they're getting.

No new dependencies — `soxr`, `scipy`, `resampy`, and `samplerate` were already required.

## Test plan

- [x] New regression suite in `test/tests/test_resample_aaf.py`:
  - 7 kHz tone in 16 kHz signal downsampled to 8 kHz: alias at 1 kHz must be ≥ 40 dB below a real reference tone (PASS).
  - Contrast test: legacy `resample_signal` *does* alias on the same input — locks in that the new path is doing real work (PASS).
  - In-band tone (1 kHz) survives the resample (PASS).
  - Shape and dtype contract preserved at 48 kHz → 16 kHz and 44.1 kHz → 22.05 kHz (PASS).
- [x] Diff comparison vs `main`: 1 fewer test failure (the s3 resample bug is now fixed) and 0 new failures. Remaining failures on this branch are the same pre-existing harness/data issues that already exist on `main` (e.g. `test_resample_2d` asserts shape-preservation on a shape-changing function; `test_wav_loader_shape` requires `examples/data/yes.wav` which is not in the repo).